### PR TITLE
系统用户名带空格代码运行bat文件报错

### DIFF
--- a/src/run/TerminalExec.java
+++ b/src/run/TerminalExec.java
@@ -70,7 +70,7 @@ public class TerminalExec {
 				cmdContent = String.format("osascript -e 'tell app \"Terminal\" to do script \"%s\"'",cmdContent);
 			}
 			FileUtils.writeByteArrayToFile(batFile, cmdContent.getBytes());
-			return batFile.getAbsolutePath();
+			return "\""+batFile.getAbsolutePath()+"\"";
 		} catch (IOException e) {
 			e.printStackTrace();
 			return null;


### PR DESCRIPTION
由于系统用户名带有空格，运行bat文件的时候同样也存在问题。在genBatchFile类返回值前面添加双引号